### PR TITLE
`Spec.conform_valid` can now propogate through nested Specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can use `Spec.compose_conformer`, which will compose your conformer after any
   existing conformers on a Spec instance and return a copy with that composition.
   (#65)
-- **Breaking** `dataspec.Conformer` is now `dataspec.ConformerFn` as a
+- `dataspec.Conformer` is now the union of `dataspec.ConformerFn` (a single argument
+  function returning a value or an instance of `Invalid`) and `dataspec.IConformer`.
+  The latter is a new interface used internally allow calls to `Spec.conform_valid` to
+  propogate through nested data structure Specs. Current uses of `Conformer` should
+  remain valid. (#51)
 
 ### Fixed
 - Fixed a bug where `s(None)` is not a valid alias for `s(type(None))` (#61)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can use `Spec.compose_conformer`, which will compose your conformer after any
   existing conformers on a Spec instance and return a copy with that composition.
   (#65)
+- **Breaking** `dataspec.Conformer` is now `dataspec.ConformerFn` as a
 
 ### Fixed
 - Fixed a bug where `s(None)` is not a valid alias for `s(type(None))` (#61)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,7 +28,7 @@ Types
 -----
 
 .. automodule:: dataspec
-   :members: Spec, SpecPredicate, Tag, Conformer, PredicateFn, ValidatorFn
+   :members: Spec, SpecPredicate, Tag, Conformer, IConformer, ConformerFn, PredicateFn, ValidatorFn
    :noindex:
 
 .. _spec_errors:

--- a/src/dataspec/__init__.py
+++ b/src/dataspec/__init__.py
@@ -4,6 +4,7 @@ from dataspec.base import (
     Conformer,
     ConformerFn,
     ErrorDetails,
+    IConformer,
     Invalid,
     PredicateFn,
     Spec,
@@ -17,10 +18,11 @@ from dataspec.factories import register_str_format, register_str_format_spec, ta
 
 __all__ = [
     "INVALID",
-    "Invalid",
     "Conformer",
     "ConformerFn",
     "ErrorDetails",
+    "IConformer",
+    "Invalid",
     "PredicateFn",
     "SpecAPI",
     "SpecPredicate",

--- a/src/dataspec/__init__.py
+++ b/src/dataspec/__init__.py
@@ -2,6 +2,7 @@ from dataspec.api import SpecAPI, s
 from dataspec.base import (
     INVALID,
     Conformer,
+    ConformerFn,
     ErrorDetails,
     Invalid,
     PredicateFn,
@@ -18,6 +19,7 @@ __all__ = [
     "INVALID",
     "Invalid",
     "Conformer",
+    "ConformerFn",
     "ErrorDetails",
     "PredicateFn",
     "SpecAPI",


### PR DESCRIPTION
Fixes #51 

This is built on top of #66 , so that PR should merge first and then the base of this PR should be changed to `master`.