### PR TITLE
Improve type annotations

### DIFF
--- a/src/dataspec/base.py
+++ b/src/dataspec/base.py
@@ -1021,7 +1021,7 @@ def type_spec(
 
 
 def type_spec(
-    tag=None, tp=object, conformer=None,
+    tag: Optional[Tag] = None, tp: Type = object, conformer: Optional[Conformer] = None
 ):
     """Return a spec that validates inputs are instances of tp."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,9 +74,7 @@ class TestSpecConformerComposition:
     @pytest.fixture
     def coll_spec_with_conformer_kwarg(self) -> Spec:
         # Test composition with the `s` constructor `conformer` keyword
-        x = s([s.str(regex=r"\d+", conformer=int)], conformer=sum)
-        v = x.conform(["1", "2", "3"])
-        return v
+        return s([s.str(regex=r"\d+", conformer=int)], conformer=sum)
 
     def test_coll_spec_with_outer_conformer_from_kwarg(
         self, coll_spec_with_conformer_kwarg: Spec

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,7 +74,9 @@ class TestSpecConformerComposition:
     @pytest.fixture
     def coll_spec_with_conformer_kwarg(self) -> Spec:
         # Test composition with the `s` constructor `conformer` keyword
-        return s([s.str(regex=r"\d+", conformer=int)], conformer=sum)
+        x = s([s.str(regex=r"\d+", conformer=int)], conformer=sum)
+        v = x.conform(["1", "2", "3"])
+        return v
 
     def test_coll_spec_with_outer_conformer_from_kwarg(
         self, coll_spec_with_conformer_kwarg: Spec


### PR DESCRIPTION
This is an experimental PR to try to improve the quality and precision of type annotations on builtin base types and factories. In its current form, I've added two generic parameters to the `dataspec.Spec` interface. The first parameter indicates the _valid_ input type and the second is the expected return type from `dataspec.Spec.conform` (and thus the type accepted by `dataspec.Spec.conform_valid`). These don't work in all cases and I had to dump out to `Any` in several instances. Furthermore, primarily dynamic operations like composing multiple conformers procedurally cannot be sufficiently expressed using MyPy's existing generic facilities (or, at least, I don't know how to do it).

The other major addition is multiple overloaded signatures for classmethod constructors (and soon, for `make_spec`/`s`) which will probably allow MyPy to check types much more richly than before.

I'm leaving this in a draft state now and I'll continue to work on it as I have time.